### PR TITLE
Fix deprecated TabNavigator

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,11 +1,11 @@
 import React from 'react'
-import { TabNavigator } from 'react-navigation'
+import { createBottomTabNavigator } from 'react-navigation'
 import MapScreen from './screens/Map/MapScreen'
 import CompaniesScreen from './screens/Companies/CompaniesScreen'
 import EventsScreen from './screens/Events/EventsScreen'
 import AboutScreen from './screens/About/AboutScreen'
 
-const Router = TabNavigator({
+const Router = createBottomTabNavigator({
   Map: {
     screen: MapScreen
   },


### PR DESCRIPTION
## Change description

Changes TabNavigator to createBottomTabNavigator as TabNavigator is deprecated in react-navigation v2 (reference https://reactnavigation.org/docs/en/tab-based-navigation.html).

## How to verify

Run the app and switch between tabs, the warning `Method jumpToIndex is deprecated. Please upgrade your code to use jumpTo instead.` should not be shown anymore.

## Issues fixed

This fixes #5.
