### PR TITLE
Create simple row and events list view

### DIFF
--- a/src/components/listItems/EventListItem.js
+++ b/src/components/listItems/EventListItem.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Text } from 'react-native'
+import PropTypes from 'prop-types'
+import ListItem from './ListItem'
+
+const styles = {
+  title: {
+    fontSize: 16
+  }
+}
+
+const { title } = styles
+const EventListItem = ({ navigation, item }) => (
+  <ListItem navigation={navigation} item={item}>
+    <Text style={title}>{item.title}</Text>
+  </ListItem>
+)
+
+EventListItem.propTypes = {
+  navigation: PropTypes.shape({ navigate: PropTypes.func.isRequired })
+    .isRequired,
+  item: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired
+  }).isRequired
+}
+
+export default EventListItem

--- a/src/components/listItems/ListItem.js
+++ b/src/components/listItems/ListItem.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import { TouchableOpacity, View } from 'react-native'
+import PropTypes from 'prop-types'
+
+const styles = {
+  content: {
+    paddingVertical: 16,
+    paddingHorizontal: 8,
+    borderBottomWidth: 1,
+    borderColor: 'gray'
+  }
+}
+
+const { content } = styles
+const ListItem = ({ children, navigation, item }) => (
+  // TODO: implement navigation when stack navigator is added
+  // E.g. <TouchableOpacity onPress={() => navigation.navigate('Detail', { item })}>
+  <TouchableOpacity>
+    <View style={content}>{children}</View>
+  </TouchableOpacity>
+)
+
+ListItem.propTypes = {
+  children: PropTypes.node.isRequired,
+  navigation: PropTypes.shape({ navigate: PropTypes.func.isRequired })
+    .isRequired,
+  item: PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired
+  }).isRequired
+}
+
+export default ListItem

--- a/src/helpers/DummyData.js
+++ b/src/helpers/DummyData.js
@@ -1,0 +1,7 @@
+export const EVENT_DATA = [
+  { key: '1', title: 'Item 1' },
+  { key: '2', title: 'Item 2' },
+  { key: '3', title: 'Item 3' },
+  { key: '4', title: 'Item 4' },
+  { key: '5', title: 'Item 5' }
+]

--- a/src/screens/Events/EventsScreen.js
+++ b/src/screens/Events/EventsScreen.js
@@ -1,10 +1,21 @@
 import React from 'react'
-import { View, Text } from 'react-native'
+import { FlatList } from 'react-native'
+import PropTypes from 'prop-types'
+import EventListItem from '../../components/listItems/EventListItem'
+import { EVENT_DATA } from '../../helpers/DummyData'
 
-const EventsScreen = () => (
-  <View>
-    <Text>EventsScreen</Text>
-  </View>
+const EventsScreen = ({ navigation }) => (
+  <FlatList
+    data={EVENT_DATA}
+    renderItem={({ item }) => (
+      <EventListItem navigation={navigation} item={item} />
+    )}
+  />
 )
+
+EventsScreen.propTypes = {
+  navigation: PropTypes.shape({ navigate: PropTypes.func.isRequired })
+    .isRequired
+}
 
 export default EventsScreen


### PR DESCRIPTION
## Change description

Adding a simple list item that is used as a container for more specific ones.
Adding a event list item which uses the simple list item.
Adding a flat list on events screen that uses the event list item.

## How to verify

Run the app and check the Events tab. Five list items should be shown named Item 1, Item 2, Item 3, Item 4 and Item 5.

## Issues fixed

This fixes #8, fixes #9.
