### PR TITLE
Add section titles on companies screen

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="stateAlwaysHidden">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />

--- a/src/screens/Companies/CompaniesScreen.js
+++ b/src/screens/Companies/CompaniesScreen.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react'
-import { View, FlatList, TextInput } from 'react-native'
+import {
+  TextInput, Keyboard, SectionList, View, Text
+} from 'react-native'
 import PropTypes from 'prop-types'
 import Icon from 'react-native-vector-icons/FontAwesome'
 import LoadingView from '../../components/LoadingView'
@@ -34,6 +36,12 @@ const styles = {
     marginRight: 8,
     borderBottomRightRadius: 8,
     borderTopRightRadius: 8
+  },
+  sectionHeader: {
+    padding: 8,
+    backgroundColor: '#eee',
+    borderBottomWidth: 1,
+    borderColor: '#ccc'
   }
 }
 
@@ -63,6 +71,15 @@ class CompaniesScreen extends Component {
     )
   }
 
+  renderSectionHeader = (title) => {
+    const { sectionHeader } = styles
+    return (
+      <View style={sectionHeader}>
+        <Text>{title}</Text>
+      </View>
+    )
+  }
+
   render() {
     const {
       navigation, companyList, loading, error, loadCompanies
@@ -74,6 +91,22 @@ class CompaniesScreen extends Component {
     if (error) {
       return <ErrorView error={error} loadCompanies={loadCompanies} />
     }
+    let sections
+    if (companyList.length === 0) {
+      sections = [{ title: 'No matches found', data: [] }]
+    } else {
+      sections = companyList.reduce((a, b) => {
+        const item = a
+        const firstLetter = b.name[0].toUpperCase()
+        if (item[firstLetter]) {
+          item[firstLetter].push(b)
+        } else {
+          item[firstLetter] = [b]
+        }
+        return item
+      }, {})
+      sections = Object.keys(sections).map(key => ({ title: key, data: sections[key] }))
+    }
     return (
       <View style={content}>
         <ShowFavoritesButton />
@@ -82,10 +115,12 @@ class CompaniesScreen extends Component {
           // Don't forget to remove the surrounding View when
           // moving the ShowFavoritesButton component
         }
-        <FlatList
+        <SectionList
           ListHeaderComponent={this.renderSearchField()}
-          data={companyList}
           renderItem={({ item }) => <CompanyListItem navigation={navigation} company={item} />}
+          renderSectionHeader={({ section: { title } }) => this.renderSectionHeader(title)}
+          sections={sections}
+          onScrollBeginDrag={() => Keyboard.dismiss()}
         />
       </View>
     )


### PR DESCRIPTION
## Change description

- Adds a section title on the companies screen. All companies are now under a section according to the first letter in their company name. The sections are ordered alphabetically
- Dismiss keyboard when starting to scroll
- Fixed a issue on Android where the tab bar was pushed up by the keyboard so that it was displayed right above the keyboard when the keyboard was active

## How to verify

Run the project and:
- Confirm that all companies are in the correct section
- Select the search field and scroll the list, the keyboard should disappear
- Confirm that the issue with the tab bar is fixed on Android.

## Issues fixed

This fixes #42.
