### PR TITLE
Fix search for companies

### DIFF
--- a/src/containers/CompaniesScreen.js
+++ b/src/containers/CompaniesScreen.js
@@ -48,17 +48,7 @@ const filterFavoritesAndSearch = (items, showFavorites, favorites, searchText) =
       return sortedItem
     })
     .filter(item => item.rating !== 0)
-    .sort((a, b) => {
-      const ratingA = a.rating
-      const ratingB = b.rating
-      if (ratingA < ratingB) {
-        return -1
-      }
-      if (ratingA > ratingB) {
-        return 1
-      }
-      return 0
-    })
+    .sort((a, b) => b.rating - a.rating)
   return companies
 }
 

--- a/src/containers/HouseScreen.js
+++ b/src/containers/HouseScreen.js
@@ -8,19 +8,7 @@ const mapStateToProps = state => ({
   selectedCompany: state.mapReducer.selectedCompany,
   companyList: state.apiReducer.items
     .filter(item => item.map === state.mapReducer.currentMap && item.boothNumber !== 0)
-    .sort((a, b) => {
-      {
-        const boothNumberA = a.boothNumber
-        const boothNumberB = b.boothNumber
-        if (boothNumberA < boothNumberB) {
-          return -1
-        }
-        if (boothNumberA > boothNumberB) {
-          return 1
-        }
-        return 0
-      }
-    })
+    .sort((a, b) => a.boothNumber - b.boothNumber)
 })
 
 function mapDispatchToProps(dispatch) {


### PR DESCRIPTION
## Change description

Fixes the search function on companies, also optimising the sorting of booth number on house screen.

## How to verify

Go to the companies tab and verify that the search function works as intended, also check the house screen so that the booth numbers are sorted correctly in the list.
Try this for both Android and iOS.

## Issues fixed

This fixes #115.
