### PR TITLE
Fork react-native-svg

### DIFF
--- a/ios/arkad_app_2018.xcodeproj/project.pbxproj
+++ b/ios/arkad_app_2018.xcodeproj/project.pbxproj
@@ -21,10 +21,10 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		166F7C18EFB4480FAE1421D7 /* libRNSVG-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 023588C17CC94C5F925CB297 /* libRNSVG-tvOS.a */; };
 		1A18853F6DDB49E38D2131B4 /* Ionicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C4A60A0473C8448896579CE9 /* Ionicons.ttf */; };
 		21137D7F5CD744AAB4F1A931 /* arkad.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 82FC0F6C33AB4F7CB7642A6E /* arkad.ttf */; };
 		2399DFA138154315806652CE /* Foundation.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AC0D12AB99114E6E839EFDCE /* Foundation.ttf */; };
-		2BF63410BF87495E905E5A22 /* libRNSVG-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A9BE9F3608A34ED0A04D2DDB /* libRNSVG-tvOS.a */; };
 		2C059CC32F1A45679FACBB43 /* FontAwesome5_Solid.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E9793CEC99954C50B7DC5E1B /* FontAwesome5_Solid.ttf */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
@@ -44,6 +44,7 @@
 		60ACA56AD7244D35AD64743D /* MaterialCommunityIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 27026769799B40EB85ED410B /* MaterialCommunityIcons.ttf */; };
 		628C3286B53545E3BDE35236 /* FontAwesome5_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6D2C90196D4C4EA5AEB327C2 /* FontAwesome5_Regular.ttf */; };
 		63D0817629914002A7B3E58C /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D09A452AC37B4F07B18C8F67 /* libRNVectorIcons.a */; };
+		701FEC8A6EDA44F58AE99209 /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E38ED6174704495BC4DF804 /* libRNSVG.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		83329E7498E647BFABA715E5 /* FontAwesome5_Brands.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D8B6BD269BCD4791A5E2EC45 /* FontAwesome5_Brands.ttf */; };
 		8A28A654A6AE4AD2A446AF1B /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CC09C9AD53FA4208B1C2B47F /* MaterialIcons.ttf */; };
@@ -53,7 +54,6 @@
 		C185C7942140013C0034B0F8 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C185C76E2140013C0034B0F8 /* FontAwesome.ttf */; };
 		C185C7952140013C0034B0F8 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C185C76E2140013C0034B0F8 /* FontAwesome.ttf */; };
 		D07FBB273CB94410AD5E9FC0 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C61EFAED7088442CA97236FC /* Octicons.ttf */; };
-		E23F1E0BDE7C4E648D3EE9BA /* libRNSVG.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 896B783FCCC848109167FFDF /* libRNSVG.a */; };
 		E54A7880441F45B58E839282 /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 0A846A0A726448369ABC42BB /* EvilIcons.ttf */; };
 		EC81AF25E36B4D6383341CEE /* SimpleLineIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6F2B3461876E48BAAEAA8490 /* SimpleLineIcons.ttf */; };
 		F7AE9774E27543EBBAD10022 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 95E7459EB1224144BD9D4161 /* Entypo.ttf */; };
@@ -356,16 +356,16 @@
 			remoteGlobalIDString = 5DBEB1501B18CEA900B34395;
 			remoteInfo = RNVectorIcons;
 		};
-		FF3C1D51217D2F930000C5F4 /* PBXContainerItemProxy */ = {
+		FFF008C32192D1F200AEC4A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A797BB9ACC3F420C8D894822 /* RNSVG.xcodeproj */;
+			containerPortal = 6EB10536D4F34FD1BFDDBE8F /* RNSVG.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 0CF68AC11AF0540F00FF9E5C;
 			remoteInfo = RNSVG;
 		};
-		FF3C1D53217D2F930000C5F4 /* PBXContainerItemProxy */ = {
+		FFF008C52192D1F200AEC4A0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = A797BB9ACC3F420C8D894822 /* RNSVG.xcodeproj */;
+			containerPortal = 6EB10536D4F34FD1BFDDBE8F /* RNSVG.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 94DDAC5C1F3D024300EED511;
 			remoteInfo = "RNSVG-tvOS";
@@ -382,6 +382,7 @@
 		00E356EE1AD99517003FC87E /* arkad_app_2018Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = arkad_app_2018Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* arkad_app_2018Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = arkad_app_2018Tests.m; sourceTree = "<group>"; };
+		023588C17CC94C5F925CB297 /* libRNSVG-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNSVG-tvOS.a"; sourceTree = "<group>"; };
 		0A846A0A726448369ABC42BB /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTSettings.xcodeproj; path = "../node_modules/react-native/Libraries/Settings/RCTSettings.xcodeproj"; sourceTree = "<group>"; };
 		139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTWebSocket.xcodeproj; path = "../node_modules/react-native/Libraries/WebSocket/RCTWebSocket.xcodeproj"; sourceTree = "<group>"; };
@@ -400,15 +401,14 @@
 		5E49EF298F044639B081D732 /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		6D2C90196D4C4EA5AEB327C2 /* FontAwesome5_Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Regular.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf"; sourceTree = "<group>"; };
+		6EB10536D4F34FD1BFDDBE8F /* RNSVG.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
 		6F2B3461876E48BAAEAA8490 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
+		7E38ED6174704495BC4DF804 /* libRNSVG.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSVG.a; sourceTree = "<group>"; };
 		82FC0F6C33AB4F7CB7642A6E /* arkad.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = arkad.ttf; path = ../resources/fonts/arkad.ttf; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		896B783FCCC848109167FFDF /* libRNSVG.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSVG.a; sourceTree = "<group>"; };
 		95E7459EB1224144BD9D4161 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
 		A314E65CE301497FBA9E7423 /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
-		A797BB9ACC3F420C8D894822 /* RNSVG.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
-		A9BE9F3608A34ED0A04D2DDB /* libRNSVG-tvOS.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libRNSVG-tvOS.a"; sourceTree = "<group>"; };
 		AC0D12AB99114E6E839EFDCE /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 		BF01D23446A640518E922152 /* SMXCrashlytics.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = SMXCrashlytics.xcodeproj; path = "../node_modules/react-native-fabric/ios/SMXCrashlytics.xcodeproj"; sourceTree = "<group>"; };
@@ -454,7 +454,7 @@
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				63D0817629914002A7B3E58C /* libRNVectorIcons.a in Frameworks */,
 				B0733EF6BDC04E09B89169F1 /* libSMXCrashlytics.a in Frameworks */,
-				E23F1E0BDE7C4E648D3EE9BA /* libRNSVG.a in Frameworks */,
+				701FEC8A6EDA44F58AE99209 /* libRNSVG.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -470,7 +470,7 @@
 				2D02E4C61E0B4AEC006451C7 /* libRCTSettings-tvOS.a in Frameworks */,
 				2D02E4C71E0B4AEC006451C7 /* libRCTText-tvOS.a in Frameworks */,
 				2D02E4C81E0B4AEC006451C7 /* libRCTWebSocket-tvOS.a in Frameworks */,
-				2BF63410BF87495E905E5A22 /* libRNSVG-tvOS.a in Frameworks */,
+				166F7C18EFB4480FAE1421D7 /* libRNSVG-tvOS.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -665,7 +665,7 @@
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
 				A314E65CE301497FBA9E7423 /* RNVectorIcons.xcodeproj */,
 				BF01D23446A640518E922152 /* SMXCrashlytics.xcodeproj */,
-				A797BB9ACC3F420C8D894822 /* RNSVG.xcodeproj */,
+				6EB10536D4F34FD1BFDDBE8F /* RNSVG.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -731,8 +731,8 @@
 			children = (
 				D09A452AC37B4F07B18C8F67 /* libRNVectorIcons.a */,
 				FBE0B24B917A4E70ABAB09E8 /* libSMXCrashlytics.a */,
-				896B783FCCC848109167FFDF /* libRNSVG.a */,
-				A9BE9F3608A34ED0A04D2DDB /* libRNSVG-tvOS.a */,
+				7E38ED6174704495BC4DF804 /* libRNSVG.a */,
+				023588C17CC94C5F925CB297 /* libRNSVG-tvOS.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -745,11 +745,11 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		FF3C1D4D217D2F930000C5F4 /* Products */ = {
+		FFF008BF2192D1F200AEC4A0 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FF3C1D52217D2F930000C5F4 /* libRNSVG.a */,
-				FF3C1D54217D2F930000C5F4 /* libRNSVG-tvOS.a */,
+				FFF008C42192D1F200AEC4A0 /* libRNSVG.a */,
+				FFF008C62192D1F200AEC4A0 /* libRNSVG-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -918,8 +918,8 @@
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
 				{
-					ProductGroup = FF3C1D4D217D2F930000C5F4 /* Products */;
-					ProjectRef = A797BB9ACC3F420C8D894822 /* RNSVG.xcodeproj */;
+					ProductGroup = FFF008BF2192D1F200AEC4A0 /* Products */;
+					ProjectRef = 6EB10536D4F34FD1BFDDBE8F /* RNSVG.xcodeproj */;
 				},
 				{
 					ProductGroup = C18910C72161467F0007DB5E /* Products */;
@@ -1221,18 +1221,18 @@
 			remoteRef = C18910D0216146800007DB5E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		FF3C1D52217D2F930000C5F4 /* libRNSVG.a */ = {
+		FFF008C42192D1F200AEC4A0 /* libRNSVG.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libRNSVG.a;
-			remoteRef = FF3C1D51217D2F930000C5F4 /* PBXContainerItemProxy */;
+			remoteRef = FFF008C32192D1F200AEC4A0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		FF3C1D54217D2F930000C5F4 /* libRNSVG-tvOS.a */ = {
+		FFF008C62192D1F200AEC4A0 /* libRNSVG-tvOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = "libRNSVG-tvOS.a";
-			remoteRef = FF3C1D53217D2F930000C5F4 /* PBXContainerItemProxy */;
+			remoteRef = FFF008C52192D1F200AEC4A0 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/ios/arkad_app_2018/Info.plist
+++ b/ios/arkad_app_2018/Info.plist
@@ -50,7 +50,7 @@
 		</dict>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string></string>
+	<string/>
 	<key>UIAppFonts</key>
 	<array>
 		<string>FontAwesome.ttf</string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5847,9 +5847,8 @@
       "integrity": "sha512-PrO7mg4gkvx8cTV5o+jQfXMX4iczm6J0KtbJ+x6VF2v/sHFygU6homMAWp8FwXq+ZsTOsFEjxkNAwqTf9Lnq7w=="
     },
     "react-native-svg": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-8.0.2.tgz",
-      "integrity": "sha512-R3okRr6gP6JHe6/tazl6UTqN/zrZJggvjYnnyOYwn0brIiJperLPfxXYfaLZ8B3jrRW6SOTDvHBnyR+6uGJnBg==",
+      "version": "github:tovesson/react-native-svg#9ec2eed30d18c131c95c48b09bd1d9adc3696a89",
+      "from": "github:tovesson/react-native-svg",
       "requires": {
         "color": "^2.0.1",
         "lodash": "^4.16.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-native-actionsheet": "^2.4.2",
     "react-native-fabric": "^0.5.2",
     "react-native-sectioned-multi-select": "^0.5.2",
-    "react-native-svg": "^8.0.2",
+    "react-native-svg": "github:tovesson/react-native-svg",
     "react-native-vector-icons": "^5.0.0",
     "react-navigation": "^2.9.3",
     "react-redux": "^5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3912,10 +3912,6 @@ react-native-sectioned-multi-select@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-native-sectioned-multi-select/-/react-native-sectioned-multi-select-0.5.2.tgz#5a9a93a5785c89892314950f65568e0ba6f32d97"
 
-react-native-svg-pan-zoom@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-svg-pan-zoom/-/react-native-svg-pan-zoom-0.1.2.tgz#d86ff1b25e8dabdd75439d77dc55060bb413d9de"
-
 react-native-tab-view@^0.0.77:
   version "0.0.77"
   resolved "http://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-0.0.77.tgz#11ceb8e7c23100d07e628dc151b57797524d00d4"


### PR DESCRIPTION
## Change description

Forks the react-native-svg library, removing the issue with ignored touch events.

## How to verify

Launch the app on the simulator and a real device for iOS and Android. Confirm that the map works. For real device you need to wait for it to be out for beta testing (PR can be merged before that).

## Issues fixed

This fixes #129.
